### PR TITLE
update.js should update image with .gif

### DIFF
--- a/utils/update.js
+++ b/utils/update.js
@@ -14,7 +14,7 @@ let data = JSON.parse(rawdata);
 
 data.forEach((item) => {
   item.description = description;
-  item.image = `${baseUri}/${item.edition}.png`;
+  item.image = `${baseUri}/${item.edition}.gif`;
   fs.writeFileSync(
     `${basePath}/build/json/${item.edition}.json`,
     JSON.stringify(item, null, 2)


### PR DESCRIPTION
The update.js code taken from HashLips as referenced in the README updates the image field in each JSON file with a .png extension. A user of our platform at https://www.candychain.io/ noticed that the script was causing his generated metadata to point to .png files.